### PR TITLE
Support for multiple form fields with the same name

### DIFF
--- a/src/jquery.deserialize.js
+++ b/src/jquery.deserialize.js
@@ -58,7 +58,7 @@ jQuery.fn.extend({
 			return this;
 		}
 
-		var current, element, item, j, len, property, type;
+		var current, element, item, j, len, property, type, lastname;
 
 		for ( i = 0; i < length; i++ ) {
 			current = normalized[ i ];
@@ -83,17 +83,28 @@ jQuery.fn.extend({
 
 			// Handle element group
 			if ( len ) {
-				for ( j = 0; j < len; j++ ) {
-					item = element [ j ];
+				if ( property !== "value" ) {
+					for ( j = 0; j < len; j++ ) {
+						item = element [ j ];
 
-					if ( item.value == current.value ) {
-						item[ property ] = true;
+						if ( item.value == current.value ) {
+							item[ property ] = true;
+						}
 					}
-				}
+				} else {
+					current.name !== lastname ? j = 0 : ++j;
 
+					item = element [ j ];
+					
+					if ( item !== undefined ) {
+						item[ property ] = current.value;
+					}
+
+					lastname = current.name;				
+				}
 			} else {
 				element[ property ] = current.value;
-			}
+			}					
 		}
 
 		if ( jQuery.isFunction( callback ) ) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -35,6 +35,8 @@
             <h4>Text</h4>
             <input name="text" type="text" value="" />
             <input name="textarray[]" type="text" value="" />
+            <input name="multtext" type="hidden" value="" />
+            <input name="multtext" type="hidden" value="" />
           </li>
           <li>
             <h4>Textarea</h4>

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -7,12 +7,12 @@ test("Basic Requirements", function() {
   ok($, "$");
 });
 
-var str = "text=text+with+spaces&textarea=textarea&radio=3&checkbox=2&checkbox=3&select=3&selectMultiple=2&selectMultiple=3",
-	encodedStr = "text=" + encodeURIComponent( "Thyme &time=again" ),
+var str = "text=text+with+spaces&textarea=textarea&multtext=hi&multtext=hello&radio=3&checkbox=2&checkbox=3&select=3&selectMultiple=2&selectMultiple=3",
+  encodedStr = "text=" + encodeURIComponent( "Thyme &time=again" ),
     encodedFieldNameStr = encodeURIComponent( "textarray[]" ) + "=textarray";
 
 test("jQuery.deserialize(string)", function() {
-  expect(8);
+  expect(9);
 
   var $form = $("#form"), form = $form.get(0);
 
@@ -22,6 +22,9 @@ test("jQuery.deserialize(string)", function() {
 
   equals(form.text.value, "text with spaces", "Serialized String: text with spaces");
   equals(form.textarea.value, "textarea", "Serialized String: textarea");
+  equals($form.find("[name=multtext]").map(function() {
+    return this.value;
+  }).get().join(","), "hi,hello", "Serialized Array: multiple hidden");
   equals($form.find("[name=radio]:checked").val(), "3", "Serialized String: radio");
   equals($form.find("[name=checkbox]:checked").map(function() {
     return this.value;
@@ -48,6 +51,8 @@ test("jQuery.deserialize(string)", function() {
 var arr = [
   { name: "text", value: "text" },
   { name: "textarea", value: "textarea" },
+  { name: "multtext", value: "hi" },
+  { name: "multtext", value: "hello" },
   { name: "radio", value: 3 },
   { name: "checkbox", value: 2 },
   { name: "checkbox", value: 3 },
@@ -57,7 +62,7 @@ var arr = [
 ];
 
 test("jQuery.deserialize(array)", function() {
-  expect(6);
+  expect(7);
 
   var $form = $("#form"), form = $form.get(0);
 
@@ -67,6 +72,9 @@ test("jQuery.deserialize(array)", function() {
 
   equals(form.text.value, "text", "Serialized Array: text");
   equals(form.textarea.value, "textarea", "Serialized Array: textarea");
+  equals($form.find("[name=multtext]").map(function() {
+    return this.value;
+  }).get().join(","), "hi,hello", "Serialized Array: multiple hidden");
   equals($form.find("[name=radio]:checked").val(), "3", "Serialized Array: radio");
   equals($form.find("[name=checkbox]:checked").map(function() {
     return this.value;
@@ -80,6 +88,7 @@ test("jQuery.deserialize(array)", function() {
 var obj = {
   text: "text",
   textarea: "textarea",
+  multtext: ["hi", "hello"],
   radio: 3,
   checkbox: [2, 3],
   select: 3,
@@ -87,7 +96,7 @@ var obj = {
 };
 
 test("jQuery.deserialize(object)", function() {
-  expect(6);
+  expect(7);
 
   var $form = $("#form"), form = $form.get(0);
 
@@ -97,6 +106,9 @@ test("jQuery.deserialize(object)", function() {
 
   equals(form.text.value, "text", "Serialized Array: text");
   equals(form.textarea.value, "textarea", "Serialized Array: textarea");
+  equals($form.find("[name=multtext]").map(function() {
+    return this.value;
+  }).get().join(","), "hi,hello", "Serialized Array: multiple hidden");
   equals($form.find("[name=radio]:checked").val(), "3", "Serialized Array: radio");
   equals($form.find("[name=checkbox]:checked").map(function() {
     return this.value;


### PR DESCRIPTION
I found your excellent deserialize plugin and found it worked perfectly for me except for one thing that I have to deal with in some legacy code, multiple form inputs that have the same name. It would populate the inputs with 'true' instead of the actual value, which is what this patch provides. This was helpful for me and I thought I would write the unit tests and submit it for others to use.
