### PR TITLE
element lookup in array

### DIFF
--- a/src/jquery.deserialize.js
+++ b/src/jquery.deserialize.js
@@ -65,8 +65,8 @@ jQuery.fn.extend({
             current = normalized[ i ];
 
             if ( !( element = elements[ current.name ]
-            		|| jQuery.grep( elements, function(e){ return e.id == current.name } )[0] 
-    				|| jQuery.grep( elements, function(e){ return e.name == current.name } ) ) ) {
+            		|| jQuery.grep( elements, function(e){ return e.id == current.name; } )[0] 
+    				|| jQuery.grep( elements, function(e){ return e.name == current.name; } ) ) ) {
                 continue;
             }
 


### PR DESCRIPTION
If the elements retrieved from the parent node is in array instead of HTMLCollection, the element lookup will be broken. This patch will fix it. Please merge it. Cheers.
