### PR TITLE
Tweak to deserialize even in the presence of the jQuery Uniform UI lib

### DIFF
--- a/src/jquery.deserialize.js
+++ b/src/jquery.deserialize.js
@@ -134,6 +134,12 @@ jQuery.fn.deserialize = function( data, options ) {
         }
     }
 
+    //If the jQuery Uniform UI library is being used, then update those custom UI controls 
+    //based on the state of the underlying native form controls we've just updated
+    if (window.jQuery && jQuery.uniform) {
+        jQuery.uniform.update();
+    }
+    
     complete.call( this );
 
     return this;


### PR DESCRIPTION
Hello !

I've added a little tweak here to make the library work with Uniform.JS as the library hides the native forms controls so when your library updates the properties, it doesn't know of the change. This will cause it to invalidate state of their own controls and refresh them based on the native form controls.

Tested :)
