### PR TITLE
Fix bugs when an input name is used across elements of different types

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -69,6 +69,93 @@
               <option value="3">3</option>
             </select>
           </li>
+          <li>
+            <h4>Multiple Select Lists With Same Name</h4>
+            <select name="selectMultipleDuplicate" multiple="multiple">
+              <option value="1" selected="selected">1</option>
+              <option value="2" selected="selected">2</option>
+              <option value="3">3</option>
+            </select>
+            <select name="selectMultipleDuplicate" multiple="multiple">
+              <option value="4">4</option>
+              <option value="5" selected="selected">5</option>
+            </select>
+          </li>
+          <li>
+            <h4>Lone Checkbox With Hidden Default (checked)</h4>
+            <input name="loneCheckboxWithHiddenChecked" type="hidden" value="false" />
+            <label class="checkbox"><input name="loneCheckboxWithHiddenChecked" type="checkbox" value="true" checked="checked" />true</label>
+          </li>
+          <li>
+            <h4>Lone Checkbox With Hidden Default (unchecked)</h4>
+            <input name="loneCheckboxWithHiddenUnchecked" type="hidden" value="false" />
+            <label class="checkbox"><input name="loneCheckboxWithHiddenUnchecked" type="checkbox" value="true" />true</label>
+          </li>
+          <li>
+            <h4>Checkbox Group With Hidden Default (checked)</h4>
+            <span class="group">
+              <input name="checkboxGroupWithHiddenChecked" type="hidden" value="false" />
+              <label class="checkbox"><input name="checkboxGroupWithHiddenChecked" type="checkbox" value="1" checked="checked" />1</label>
+              <label class="checkbox"><input name="checkboxGroupWithHiddenChecked" type="checkbox" value="2" />2</label>
+              <label class="checkbox"><input name="checkboxGroupWithHiddenChecked" type="checkbox" value="3" checked="checked" />3</label>
+            </span>
+          </li>
+          <li>
+            <h4>Checkbox Group With Hidden Default (unchecked)</h4>
+            <span class="group">
+              <input name="checkboxGroupWithHiddenUnchecked" type="hidden" value="false" />
+              <label class="checkbox"><input name="checkboxGroupWithHiddenUnchecked" type="checkbox" value="1" />1</label>
+              <label class="checkbox"><input name="checkboxGroupWithHiddenUnchecked" type="checkbox" value="2" />2</label>
+              <label class="checkbox"><input name="checkboxGroupWithHiddenUnchecked" type="checkbox" value="3" />3</label>
+            </span>
+          </li>
+          <li>
+            <h4>Multiple Select List With Hidden Default (with selections)</h4>
+            <input name="selectMultipleWithHiddenWithSelections" type="hidden" value="false" />
+            <select name="selectMultipleWithHiddenWithSelections" multiple="multiple">
+              <option value="1" selected="selected">1</option>
+              <option value="2" selected="selected">2</option>
+              <option value="3">3</option>
+            </select>
+          </li>
+          <li>
+            <h4>Multiple Select List With Hidden Default (no selections)</h4>
+            <input name="selectMultipleWithHiddenNoSelections" type="hidden" value="false" />
+            <select name="selectMultipleWithHiddenNoSelections" multiple="multiple">
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+            </select>
+          </li>
+          <li>
+            <h4>Multiple Select List With Checkbox After</h4>
+            <select name="selectMultipleWithCheckboxAfter" multiple="multiple">
+              <option value="1" selected="selected">1</option>
+              <option value="2" selected="selected">2</option>
+              <option value="3">3</option>
+            </select>
+            <input name="selectMultipleWithCheckboxAfter" type="checkbox" value="4" checked="checked" />
+          </li>
+          <li>
+            <h4>Multiple Select List With Checkboxes Before and After</h4>
+            <input name="selectMultipleWithCheckboxesSurrounding" type="checkbox" value="0" checked="checked" />
+            <select name="selectMultipleWithCheckboxesSurrounding" multiple="multiple">
+              <option value="1" selected="selected">1</option>
+              <option value="2" selected="selected">2</option>
+              <option value="3">3</option>
+            </select>
+            <input name="selectMultipleWithCheckboxesSurrounding" type="checkbox" value="4" checked="checked" />
+          </li>
+          <li>
+            <h4>Multiple Select List With Checkboxes Before and After</h4>
+            <input name="selectMultipleWithHiddenAndCheckbox" type="hidden" value="false" />
+            <select name="selectMultipleWithHiddenAndCheckbox" multiple="multiple">
+              <option value="1">1</option>
+              <option value="2" selected="selected">2</option>
+              <option value="3">3</option>
+            </select>
+            <input name="selectMultipleWithHiddenAndCheckbox" type="checkbox" value="4" />
+          </li>
         </ol>
         <input name="multtext" type="hidden" value="howdy" />
       </form>

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -29,15 +29,22 @@ $.each( [ "serialize", "serializeArray", "serializeObject" ], function( i, seria
             var changeCalledCount = 0,
                 data = $form[ serializeMethod ]();
 
-            $form.get( 0 ).reset();
+            // Completely clear the form of any values to ensure deserialize
+            // repopulates the form (this differs from a form.reset(), since
+            // reset only resets back to the default state from initial page
+            // load).
+            $form.not(':button, :submit, :reset, :hidden, :checkbox, :radio, select, option').val('');
+            $(':checkbox, :radio').removeAttr('checked');
+            $('select').attr('selectedIndex', -1);
+            $('option:selected').removeAttr('selected');
 
             $form.deserialize( data, {
                 change: function() {
                     changeCalledCount++;
                 },
                 complete: function() {
-                    deepEqual( data, $form[ serializeMethod ](), "Serialized data matches deserialized data (element #" + elementIndex + ")" );
-                    equal( changeCount, changeCalledCount, "Change called for each changed input (element #" + elementIndex + ")" );
+                    deepEqual( $form[ serializeMethod ](), data, "Serialized data matches deserialized data (element #" + elementIndex + ")" );
+                    equal( changeCalledCount, changeCount, "Change called for each changed input (element #" + elementIndex + ")" );
                 }
             });
         });


### PR DESCRIPTION
This helps fix the handling of situations like using a hidden input to provide a checkbox with a default value when unchecked:

```html
<input type="hidden" name="foo" value="false" />
<input type="checkbox" name="foo" value="true" />
```

This also helps fix array handling when an input name is shared across multiple different element types (with the values typically being treated as a single array):

```html
<select name="bar" multiple="multiple">
  <option value="1">1</option>
</select>
<input type="checkbox" name="bar" value="2" />
```

Tests have been added, and the test suite has been adjusted slightly:

- The previous reset() approach for the form was leading to some false-positives for these new tests. The form is now being completely cleared between tests to better test for these more complex situations.`
- Fixed the ordering of the "expected" and "actual" arguments to qunit's equal methods.

This also fixes https://github.com/kflorence/jquery-deserialize/issues/15 with a test added for that scenario.

This does change some of the internal logic more than I was hoping, but I couldn't really find a cleaner way to tackle this. Most of the issues previously stemmed from the fact that the input type detection was only being done on the first element for input groups having the same name (so in the example of a hidden field followed by a checkbox, both elements were being expected to be `value` based inputs and a checkbox was unexpected). This shifts things around so that the input type is being checked for each element. But any feedback or suggestions are welcome if you see a better way to address these scenarios I added tests for.

Thanks!