### PR TITLE
Remove redundant version tag from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "jquery-deserialize",
-  "version": "1.3.3",
   "homepage": "https://github.com/kflorence/jquery-deserialize",
   "authors": [
     "Kyle Florence <kyle.florence@gmail.com>"


### PR DESCRIPTION
Bower now uses git version tags instead (http://semver.org/).
