### PR TITLE
Add CommonJS support

### DIFF
--- a/src/jquery.deserialize.js
+++ b/src/jquery.deserialize.js
@@ -20,7 +20,15 @@
  *
  * Dual licensed under the MIT and GPLv2 licenses.
  */
-(function( jQuery, undefined ) {
+(function ( factory ) {
+    if ( typeof module === 'object' && module.exports ) {
+        // Node/CommonJS
+        module.exports = factory( require( 'jquery' ) );
+    } else {
+        // Browser globals
+        factory( window.jQuery );
+    }
+} (function( jQuery ) {
 
 var push = Array.prototype.push,
     rcheck = /^(?:radio|checkbox)$/i,
@@ -180,4 +188,4 @@ jQuery.fn.deserialize = function( data, options ) {
     return this;
 };
 
-})( jQuery );
+}));


### PR DESCRIPTION
Your module is on npm, but it can't be used as `var jqueryDeserialize = require('jquery-deserialize
')` and then compiled with Browserify. With CommonJS support it can be used this way:

```js
var jQuery = require('jquery');
var jqueryDeserialize = require('jquery-deserialize');

jQuery( 'form' ).deserialize( location.search.substr( 1 ) );
```