### PR TITLE
Allow sets of select ones to behave like text inputs

### DIFF
--- a/src/jquery.deserialize.js
+++ b/src/jquery.deserialize.js
@@ -206,6 +206,12 @@
 
     // Handle select menus, checkboxes and radio buttons
     } else if ( property == "checked" || property == "selected" ) {
+
+      // If the selects are select-ones then only update matching index with value
+      if( element.options && !element.multiple && elementIndex != valueIndex ){
+        return;
+      }
+
       var fields = [];
 
       // Extract option fields from select menus


### PR DESCRIPTION
Multi Selects aren't very intuitive to use for most users (in my experience), so using multiple `select-one`s in series with the same field name is common for me. Being able to have those act the same as inputs with the same name allows spreading of the values out.

There may be a better way to do this, but I was going for quick and using the data that was readily available at that point in the code. If there is a suggestion for another approach I'd be happy to implement it.